### PR TITLE
refactor: Refactor Http interfaces

### DIFF
--- a/HttpMessage/HttpMessage.cpp
+++ b/HttpMessage/HttpMessage.cpp
@@ -14,6 +14,10 @@ apouche::IHttpHeader *apouche::HttpMessage::getHeaders() {
     return _header;
 }
 
+const apouche::IHttpHeader *apouche::HttpMessage::getHeaders() const {
+    return _header;
+}
+
 void apouche::HttpMessage::setHeaders(IHttpHeader *header) {
     _header = header;
 }
@@ -22,11 +26,15 @@ apouche::IHttpBody *apouche::HttpMessage::getBody() {
     return _body;
 }
 
+const apouche::IHttpBody *apouche::HttpMessage::getBody() const {
+    return _body;
+}
+
 void apouche::HttpMessage::setBody(IHttpBody *body) {
     _body = body;
 }
 
-const std::string &apouche::HttpMessage::getVersion() {
+const std::string &apouche::HttpMessage::getVersion() const {
     return _version;
 }
 

--- a/HttpMessage/HttpMessage.hh
+++ b/HttpMessage/HttpMessage.hh
@@ -57,7 +57,12 @@ namespace apouche {
         *
         *  \return apouche::IHttpHeader : Your header of the request or response
         */
-        IHttpHeader *getHeaders();
+        IHttpHeader *getHeaders() override;
+        /*!
+         * \brief Constant version of getHeaders()
+         * @return apouche::IHttpHeader: Your header of the request or response
+         */
+        const IHttpHeader *getHeaders() const override;
         /*!
         *  \brief Set the IHttpHeader of your request or response
         *
@@ -66,7 +71,7 @@ namespace apouche {
         *  \param header : set the IHttpHeader of your request or response
         *  \return void
         */
-        void setHeaders(IHttpHeader *header);
+        void setHeaders(IHttpHeader *header) override;
         /*!
         *  \brief Get the IHttpBody of your message, you can give you own implementation or use our implementation.
         *
@@ -74,7 +79,12 @@ namespace apouche {
         *
         *  \return apouche::IHttpBody: Your body of the request or response
         */
-        IHttpBody *getBody();
+        IHttpBody *getBody() override;
+        /*!
+         * \brief Constant version of getBody()
+         * @return apouche::IHttpBody: Your body of the request or response
+         */
+        const IHttpBody *getBody() const override;
         /*!
         *  \brief Set the IHttpBody of your request or response
         *
@@ -83,7 +93,7 @@ namespace apouche {
         *  \param body : set the IHttpBody of your request or response
         *  \return void
         */
-        void setBody(IHttpBody *body);
+        void setBody(IHttpBody *body) override;
         /*!
         *  \brief Get the http version of your message.
         *
@@ -91,7 +101,7 @@ namespace apouche {
         *
         *  \return std::string: The http version used for your request or response
         */
-        const std::string &getVersion();
+        const std::string &getVersion() const override;
         /*!
         *  \brief Set the http version of your message.
         *
@@ -99,7 +109,7 @@ namespace apouche {
         *
         *  \param version, The http version for your request or response
         */
-        void setVersion(const std::string &version);
+        void setVersion(const std::string &version) override;
     };
 }
 

--- a/HttpMessage/IHttpMessage.hh
+++ b/HttpMessage/IHttpMessage.hh
@@ -41,6 +41,11 @@ namespace apouche {
         */
         virtual IHttpHeader *getHeaders()= 0;
         /*!
+         * \brief Constant version of getHeaders()
+         * @return apouche::IHttpHeader: Your header of the request or response
+         */
+        virtual const IHttpHeader *getHeaders() const = 0;
+        /*!
         *  \brief Set the IHttpHeader of your request or response
         *
         *  Set the IHttpHeader of your request or response
@@ -58,6 +63,11 @@ namespace apouche {
         */
         virtual IHttpBody *getBody()= 0;
         /*!
+         * \brief Constant version of getBody()
+         * @return apouche::IHttpBody: Your body of the request or response
+         */
+        virtual const IHttpBody *getBody() const = 0;
+        /*!
         *  \brief Set the IHttpBody of your request or response
         *
         *  Set the IHttpBody of your request or response
@@ -73,7 +83,7 @@ namespace apouche {
         *
         *  \return std::string: The http version used for your request or response
         */
-        virtual const std::string &getVersion()= 0;
+        virtual const std::string &getVersion() const = 0;
         /*!
         *  \brief Set the http version of your message.
         *

--- a/HttpRequest/HttpRequest.cpp
+++ b/HttpRequest/HttpRequest.cpp
@@ -10,15 +10,15 @@ apouche::HttpRequest::~HttpRequest() {
 
 }
 
-const apouche::Method &apouche::HttpRequest::getMethod() {
+apouche::Method apouche::HttpRequest::getMethod() const {
     return _method;
 }
 
-void apouche::HttpRequest::setMethod(const apouche::Method &method) {
+void apouche::HttpRequest::setMethod(apouche::Method method) {
     _method = method;
 }
 
-const std::string &apouche::HttpRequest::getURI() {
+const std::string &apouche::HttpRequest::getURI() const {
     return _URI;
 }
 
@@ -26,16 +26,16 @@ void apouche::HttpRequest::setURI(const std::string &URI) {
     _URI = URI;
 }
 
-const bool apouche::HttpRequest::containsUriParameters(const std::string &key) {
+bool apouche::HttpRequest::containsUriParameters(const std::string &key) const {
     return !(_uriParameters.find(key) == _uriParameters.end());
 }
 
-std::map<std::string, std::string> apouche::HttpRequest::getUriParameters() {
+const std::map<std::string, std::string> &apouche::HttpRequest::getUriParameters() const {
     return _uriParameters;
 }
 
-const std::string &apouche::HttpRequest::getUriParameter(const std::string &key) {
-    return _uriParameters[key];
+const std::string &apouche::HttpRequest::getUriParameter(const std::string &key) const {
+    return _uriParameters.at(key);
 }
 
 void apouche::HttpRequest::setUriParameter(const std::string &key, const std::string &value) {
@@ -54,6 +54,10 @@ apouche::IHttpHeader *apouche::HttpRequest::getHeaders() {
     return _header;
 }
 
+const apouche::IHttpHeader *apouche::HttpRequest::getHeaders() const {
+    return _header;
+}
+
 void apouche::HttpRequest::setHeaders(IHttpHeader *header) {
     _header = header;
 }
@@ -62,11 +66,15 @@ apouche::IHttpBody *apouche::HttpRequest::getBody() {
     return _body;
 }
 
+const apouche::IHttpBody *apouche::HttpRequest::getBody() const {
+  return _body;
+}
+
 void apouche::HttpRequest::setBody(IHttpBody *body) {
     _body = body;
 }
 
-const std::string &apouche::HttpRequest::getVersion() {
+const std::string &apouche::HttpRequest::getVersion() const {
     return _version;
 }
 

--- a/HttpRequest/HttpRequest.hh
+++ b/HttpRequest/HttpRequest.hh
@@ -56,7 +56,7 @@ namespace apouche {
         *
         *  \return apouche::Method : The type of the request, maybe post, get, etc...
         */
-        const apouche::Method &getMethod();
+        apouche::Method getMethod() const override;
         /*!
         *  \brief Set the method of the header
         *
@@ -65,7 +65,7 @@ namespace apouche {
         *  \param method : set the type of the request, maybe post, get, etc...
         *  \return void
         */
-        void setMethod(const apouche::Method &);
+        void setMethod(apouche::Method) override;
         /*!
         *  \brief Get the uri
         *
@@ -73,7 +73,7 @@ namespace apouche {
         *
         *  \return std::string : complete uri of the Header
         */
-        const std::string &getURI();
+        const std::string &getURI() const override;
         /*!
         *  \brief Set the uri of the header
         *
@@ -81,7 +81,7 @@ namespace apouche {
         *
         *  \param uri : set the uri of the request
         */
-        void setURI(const std::string &);
+        void setURI(const std::string &) override;
         /*!
         *  \brief Check if a get parameter is in the uri
         *
@@ -90,7 +90,7 @@ namespace apouche {
         *  \param key : a get parameter key in the uri
         *  \return bool : true if the key have a value
         */
-        const bool containsUriParameters(const std::string &);
+        bool containsUriParameters(const std::string &) const override;
         /*!
         *  \brief Get all get parameters in the uri
         *
@@ -98,7 +98,7 @@ namespace apouche {
         *
         *  \return std::map<std::string, std::string> : all get parameters in the uri
         */
-        std::map<std::string, std::string> getUriParameters();
+        const std::map<std::string, std::string> &getUriParameters() const override;
         /*!
         *  \brief Set all get parameters in the uri
         *
@@ -106,7 +106,7 @@ namespace apouche {
         *
         *  \param map : all get parameters in the uri
         */
-        void setUriParameters(const std::map<std::string, std::string> &);
+        void setUriParameters(const std::map<std::string, std::string> &) override;
         /*!
         *  \brief Check if a get parameter is in the uri
         *
@@ -115,7 +115,7 @@ namespace apouche {
         *  \param key : a get parameter key in the uri
         *  \return std::string : value of the key
         */
-        const std::string &getUriParameter(const std::string &);
+        const std::string &getUriParameter(const std::string &key) const override;
         /*!
         *  \brief Set a get parameters in the uri
         *
@@ -123,7 +123,7 @@ namespace apouche {
         *
         *  \param key : a get parameter key in the uri, value : a get parameters value in the uri
         */
-        void setUriParameter(const std::string &, const std::string &);
+        void setUriParameter(const std::string &, const std::string &) override;
         /*!
         *  \brief Get the request line of your request
         *
@@ -131,7 +131,7 @@ namespace apouche {
         *
         *  \return std::string : the request line
         */
-        const std::string getRequestLine();
+        const std::string getRequestLine() override;
         /*!
         *  \brief Get the IHttpHeader of your request
         *
@@ -139,7 +139,12 @@ namespace apouche {
         *
         *  \return apouche::IHttpHeader : Your header of the request
         */
-        IHttpHeader *getHeaders();
+        IHttpHeader *getHeaders() override;
+        /*!
+         * \brief Constant version of getHeaders()
+         * @return apouche::IHttpHeader: Your header of the request or response
+         */
+        const IHttpHeader *getHeaders() const override;
         /*!
         *  \brief Set the IHttpHeader of your request
         *
@@ -148,7 +153,7 @@ namespace apouche {
         *  \param header : set the IHttpHeader of your request
         *  \return void
         */
-        void setHeaders(IHttpHeader *header);
+        void setHeaders(IHttpHeader *header) override;
         /*!
         *  \brief Get the IHttpBody of your request, you can give you own implementation or use our implementation.
         *
@@ -156,7 +161,12 @@ namespace apouche {
         *
         *  \return apouche::IHttpBody: Your body of the request or response
         */
-        IHttpBody *getBody();
+        IHttpBody *getBody() override;
+        /*!
+         * \brief Constant version of getBody()
+         * @return apouche::IHttpBody: Your body of the request or response
+         */
+        const IHttpBody *getBody() const override;
         /*!
         *  \brief Set the IHttpBody of your request
         *
@@ -165,7 +175,7 @@ namespace apouche {
         *  \param body : set the IHttpBody of your request
         *  \return void
         */
-        void setBody(IHttpBody *body);
+        void setBody(IHttpBody *body) override;
         /*!
         *  \brief Get the http version of your request.
         *
@@ -173,7 +183,7 @@ namespace apouche {
         *
         *  \return std::string: The http version used for your request
         */
-        const std::string &getVersion();
+        const std::string &getVersion() const override;
         /*!
         *  \brief Set the http version of your request.
         *
@@ -181,7 +191,7 @@ namespace apouche {
         *
         *  \param version, The http version for your request
         */
-        void setVersion(const std::string &version);
+        void setVersion(const std::string &version) override;
     };
 }
 

--- a/HttpRequest/IHttpRequest.hh
+++ b/HttpRequest/IHttpRequest.hh
@@ -43,16 +43,15 @@ namespace apouche {
         *
         *  \return apouche::Method : The type of the request, maybe post, get, etc...
         */
-        virtual const apouche::Method &getMethod()= 0;
+        virtual apouche::Method getMethod() const = 0;
         /*!
         *  \brief Set the method of the header
         *
         *  Set the method of the header
         *
         *  \param method : set the type of the request, maybe post, get, etc...
-        *  \return void
         */
-        virtual void setMethod(const apouche::Method &)= 0;
+        virtual void setMethod(apouche::Method)= 0;
         /*!
         *  \brief Get the uri
         *
@@ -60,7 +59,7 @@ namespace apouche {
         *
         *  \return std::string : complete uri of the Header
         */
-        virtual const std::string &getURI()= 0;
+        virtual const std::string &getURI() const = 0;
         /*!
         *  \brief Set the uri of the header
         *
@@ -77,7 +76,7 @@ namespace apouche {
         *  \param key : a get parameter key in the uri
         *  \return bool : true if the key have a value
         */
-        virtual const bool containsUriParameters(const std::string &)= 0;
+        virtual bool containsUriParameters(const std::string &key) const = 0;
         /*!
         *  \brief Get all get parameters in the uri
         *
@@ -85,7 +84,7 @@ namespace apouche {
         *
         *  \return std::map<std::string, std::string> : all get parameters in the uri
         */
-        virtual std::map<std::string, std::string> getUriParameters()= 0;
+        virtual const std::map<std::string, std::string> &getUriParameters() const = 0;
         /*!
         *  \brief Set all get parameters in the uri
         *
@@ -99,18 +98,19 @@ namespace apouche {
         *
         *  Check if a get parameter is in the uri
         *
-        *  \param key : a get parameter key in the uri
+        *  \param key : a GET parameter key in the uri
         *  \return std::string : value of the key
         */
-        virtual const std::string &getUriParameter(const std::string &)= 0;
+        virtual const std::string &getUriParameter(const std::string &key) const = 0;
         /*!
         *  \brief Set a get parameters in the uri
         *
         *  Set a get parameters in the uri
         *
-        *  \param key : a get parameter key in the uri, value : a get parameters value in the uri
+        *  \param key : a GET parameter key in the uri
+         * \param value : a GET parameters value in the uri
         */
-        virtual void setUriParameter(const std::string &, const std::string &)= 0;
+        virtual void setUriParameter(const std::string &key, const std::string &value)= 0;
         /*!
         *  \brief Get the request line of your request
         *
@@ -119,56 +119,6 @@ namespace apouche {
         *  \return std::string : the request line
         */
         virtual const std::string getRequestLine()= 0;
-        /*!
-        *  \brief Get the IHttpHeader of your request
-        *
-        *  Get the IHttpHeader of your request
-        *
-        *  \return apouche::IHttpHeader : Your header of the request
-        */
-        virtual IHttpHeader *getHeaders()= 0;
-        /*!
-        *  \brief Set the IHttpHeader of your request
-        *
-        *  Set the IHttpHeader of your request
-        *
-        *  \param header : set the IHttpHeader of your request
-        *  \return void
-        */
-        virtual void setHeaders(IHttpHeader *header)= 0;
-        /*!
-        *  \brief Get the IHttpBody of your request, you can give you own implementation or use our implementation.
-        *
-        *  Get the IHttpBody of your request, you can give you own implementation or use our implementation.
-        *
-        *  \return apouche::IHttpBody: Your body of the request or response
-        */
-        virtual IHttpBody *getBody()= 0;
-        /*!
-        *  \brief Set the IHttpBody of your request
-        *
-        *  Set the IHttpBody of your request
-        *
-        *  \param body : set the IHttpBody of your request
-        *  \return void
-        */
-        virtual void setBody(IHttpBody *body)= 0;
-        /*!
-        *  \brief Get the http version of your request.
-        *
-        *  Get the http version of your request.
-        *
-        *  \return std::string: The http version used for your request
-        */
-        virtual const std::string &getVersion()= 0;
-        /*!
-        *  \brief Set the http version of your request.
-        *
-        *  Set the http version of your request.
-        *
-        *  \param version, The http version for your request
-        */
-        virtual void setVersion(const std::string &version)= 0;
     };
 }
 

--- a/HttpResponse/HttpResponse.cpp
+++ b/HttpResponse/HttpResponse.cpp
@@ -8,19 +8,23 @@ apouche::HttpResponse::~HttpResponse() {
 
 }
 
-const apouche::StatusCode & apouche::HttpResponse::getStatus() {
+apouche::StatusCode apouche::HttpResponse::getStatus() const {
     return _status;
 }
 
-void apouche::HttpResponse::setStatus(const apouche::StatusCode &status) {
+void apouche::HttpResponse::setStatus(apouche::StatusCode status) {
     _status = status;
 }
 
-const std::string apouche::HttpResponse::getResponseLine() {
-    return _status + " " + _message[_status];
+const std::string apouche::HttpResponse::getResponseLine() const {
+    return _status + " " + _message.at(_status);
 }
 
 apouche::IHttpHeader *apouche::HttpResponse::getHeaders() {
+    return _header;
+}
+
+const apouche::IHttpHeader *apouche::HttpResponse::getHeaders() const {
     return _header;
 }
 
@@ -32,11 +36,15 @@ apouche::IHttpBody *apouche::HttpResponse::getBody() {
     return _body;
 }
 
+const apouche::IHttpBody *apouche::HttpResponse::getBody() const {
+    return _body;
+}
+
 void apouche::HttpResponse::setBody(IHttpBody *body) {
     _body = body;
 }
 
-const std::string &apouche::HttpResponse::getVersion() {
+const std::string &apouche::HttpResponse::getVersion() const {
     return _version;
 }
 
@@ -97,6 +105,6 @@ apouche::HttpResponse::HttpResponse(apouche::IHttpHeader *header, apouche::IHttp
     _message[StatusCode::HTTPVersionNotSupported] = "HTTPVersionNotSupported";
 }
 
-const std::string apouche::HttpResponse::getStatusDescription() {
-    return _message[_status];
+const std::string &apouche::HttpResponse::getStatusDescription() const {
+    return _message.at(_status);
 }

--- a/HttpResponse/HttpResponse.hh
+++ b/HttpResponse/HttpResponse.hh
@@ -47,7 +47,7 @@ namespace apouche {
             *  \param void
             *  \return apouche::StatusCode, status code
             */
-        const apouche::StatusCode &getStatus();
+        apouche::StatusCode getStatus() const override;
         /*!
             *  \brief Set status code
             *
@@ -56,7 +56,7 @@ namespace apouche {
             *  \param status code : apouche::StatusCode
             *  \return void
             */
-        void setStatus(const apouche::StatusCode &);
+        void setStatus(apouche::StatusCode) override;
         /*!
             *  \brief Get status code description
             *
@@ -65,7 +65,7 @@ namespace apouche {
             *  \param void
             *  \return std::string, description status code
             */
-        const std::string getStatusDescription();
+        const std::string &getStatusDescription() const override;
         /*!
             *  \brief Get the description of the status code
             *
@@ -74,7 +74,7 @@ namespace apouche {
             *  \param void
             *  \return std::string, the status of response
             */
-        const std::string getResponseLine();
+        const std::string getResponseLine() const override;
         /*!
         *  \brief Get the IHttpHeader of your response
         *
@@ -82,7 +82,12 @@ namespace apouche {
         *
         *  \return apouche::IHttpHeader : Your header of the response
         */
-        IHttpHeader *getHeaders();
+        IHttpHeader *getHeaders() override;
+        /*!
+         * \brief Constant version of getHeaders()
+         * @return apouche::IHttpHeader: Your header of the request or response
+         */
+        const IHttpHeader *getHeaders() const override;
         /*!
         *  \brief Set the IHttpHeader of your response
         *
@@ -91,7 +96,7 @@ namespace apouche {
         *  \param header : set the IHttpHeader of your response
         *  \return void
         */
-        void setHeaders(IHttpHeader *header);
+        void setHeaders(IHttpHeader *header) override;
         /*!
         *  \brief Get the IHttpBody of your response, you can give you own implementation or use our implementation.
         *
@@ -99,7 +104,12 @@ namespace apouche {
         *
         *  \return apouche::IHttpBody: Your body of the response or response
         */
-        IHttpBody *getBody();
+        IHttpBody *getBody() override;
+        /*!
+         * \brief Constant version of getBody()
+         * @return apouche::IHttpBody: Your body of the request or response
+         */
+        const IHttpBody *getBody() const override;
         /*!
         *  \brief Set the IHttpBody of your response
         *
@@ -108,7 +118,7 @@ namespace apouche {
         *  \param body : set the IHttpBody of your response
         *  \return void
         */
-        void setBody(IHttpBody *body);
+        void setBody(IHttpBody *body) override;
         /*!
         *  \brief Get the http version of your response.
         *
@@ -116,7 +126,7 @@ namespace apouche {
         *
         *  \return std::string: The http version used for your response
         */
-        const std::string &getVersion();
+        const std::string &getVersion() const override;
         /*!
         *  \brief Set the http version of your response.
         *
@@ -124,7 +134,7 @@ namespace apouche {
         *
         *  \param version, The http version for your response
         */
-        void setVersion(const std::string &version);
+        void setVersion(const std::string &version) override;
     private:
         IHttpHeader *_header; /*!< apouche::IHttpHeader. Http header of your Response */
         IHttpBody *_body; /*!< apouche::IHttpBody. Http body of your Response */

--- a/HttpResponse/IHttpResponse.hh
+++ b/HttpResponse/IHttpResponse.hh
@@ -44,7 +44,7 @@ namespace apouche {
             *  \param void
             *  \return apouche::StatusCode, status code
             */
-        virtual const apouche::StatusCode &getStatus()= 0;
+        virtual apouche::StatusCode getStatus() const = 0;
         /*!
             *  \brief Set status code
             *
@@ -53,7 +53,7 @@ namespace apouche {
             *  \param status code : apouche::StatusCode
             *  \return void
             */
-        virtual void setStatus(const apouche::StatusCode &)= 0;
+        virtual void setStatus(apouche::StatusCode)= 0;
         /*!
             *  \brief Get status code description
             *
@@ -62,7 +62,7 @@ namespace apouche {
             *  \param void
             *  \return std::string, description status code
             */
-        virtual const std::string getStatusDescription()= 0;
+        virtual const std::string &getStatusDescription() const = 0;
         /*!
             *  \brief Get the description of the status code
             *
@@ -71,57 +71,7 @@ namespace apouche {
             *  \param void
             *  \return std::string, the status of response
             */
-        virtual const std::string getResponseLine()= 0;
-        /*!
-        *  \brief Get the IHttpHeader of your response
-        *
-        *  Get the IHttpHeader of your response
-        *
-        *  \return apouche::IHttpHeader : Your header of the response
-        */
-        virtual IHttpHeader *getHeaders()= 0;
-        /*!
-        *  \brief Set the IHttpHeader of your response
-        *
-        *  Set the IHttpHeader of your response
-        *
-        *  \param header : set the IHttpHeader of your response
-        *  \return void
-        */
-        virtual void setHeaders(IHttpHeader *header)= 0;
-        /*!
-        *  \brief Get the IHttpBody of your response, you can give you own implementation or use our implementation.
-        *
-        *  Get the IHttpBody of your response, you can give you own implementation or use our implementation.
-        *
-        *  \return apouche::IHttpBody: Your body of the response or response
-        */
-        virtual IHttpBody *getBody()= 0;
-        /*!
-        *  \brief Set the IHttpBody of your response
-        *
-        *  Set the IHttpBody of your response
-        *
-        *  \param body : set the IHttpBody of your response
-        *  \return void
-        */
-        virtual void setBody(IHttpBody *body)= 0;
-        /*!
-        *  \brief Get the http version of your response.
-        *
-        *  Get the http version of your response.
-        *
-        *  \return std::string: The http version used for your response
-        */
-        virtual const std::string &getVersion()= 0;
-        /*!
-        *  \brief Set the http version of your response.
-        *
-        *  Set the http version of your response.
-        *
-        *  \param version, The http version for your response
-        */
-        virtual void setVersion(const std::string &version)= 0;
+        virtual const std::string getResponseLine() const = 0;
     };
 }
 


### PR DESCRIPTION
- Refactor IHttpMessage, IHttpRequest and IHttpResponse interfaces :
  - Make getters const methods
  - Use override keyword