### PR TITLE
refactor Apouche::EventList::getNextEvent to remove warnings

### DIFF
--- a/EventList/EventList.hpp
+++ b/EventList/EventList.hpp
@@ -74,9 +74,10 @@ namespace apouche {
                 if ((*it).getPriority() > e.getPriority())
                     e = *it;
             }
-            for (typename std::vector<Event<T, Args...>>::iterator it = _event.begin() ; it != _event.end(); ++it)
-                if ((*it).getName() == e.getName())
-                    return *it;
+            typename std::vector<Event<void, Args...>>::iterator it = _event.begin();
+            while ((*it).getName() != e.getName())
+                ++it;
+            return *it;
         }
         /*!
         *  \brief Put an Event
@@ -229,9 +230,10 @@ namespace apouche {
                 if ((*it).getPriority() > e.getPriority())
                     e = *it;
             }
-            for (typename std::vector<Event<void, Args...>>::iterator it = _event.begin() ; it != _event.end(); ++it)
-                if ((*it).getName() == e.getName())
-                    return *it;
+            typename std::vector<Event<void, Args...>>::iterator it = _event.begin();
+            while ((*it).getName() != e.getName())
+                ++it;
+            return *it;
         }
         /*!
         *  \brief Put an Event


### PR DESCRIPTION
The fact that the apouche::EventList::getNextEvent function didn't
end with a return statement triggered warnings from clang++ with the
-Weverything flag.
With this change the function is also easier to read.