### PR TITLE
fix(EventList): Fix EventList::removeEvent

### DIFF
--- a/EventList/EventList.hpp
+++ b/EventList/EventList.hpp
@@ -177,7 +177,7 @@ namespace apouche {
         *  \return void
         */
         void removeEvent (Event<void, Args...> &e) {
-            _event.erase(std::remove_if(_event.begin(), _event.end(), [const &e](Event<T, Args...> const &it) { return it.getName() == e.getName(); }), _event.end());
+            removeEvent(e.getName());
         }
         /*!
         *  \brief Call the next Event


### PR DESCRIPTION
EventList::removeEvent(Event) was not compiling.

- Fix EventList::removeEvent. It has a syntax error, fixed with a refactor.
- EventList::removeEvent(Event) now call EventList::removeEvent(std::string)