### PR TITLE
fix: IHttpMessage::setHeader and setBody delete the old object

### DIFF
--- a/HttpMessage/HttpMessage.cpp
+++ b/HttpMessage/HttpMessage.cpp
@@ -4,10 +4,17 @@
 
 #include "HttpMessage.hh"
 
-apouche::HttpMessage::HttpMessage(IHttpHeader *iHttpHeader, IHttpBody *iHttpBody, const std::string &version) {
-    _header = iHttpHeader;
-    _body = iHttpBody;
-    _version = version;
+apouche::HttpMessage::HttpMessage(IHttpHeader *iHttpHeader, IHttpBody *iHttpBody, const std::string &version)
+  : _header (iHttpHeader)
+  , _body (iHttpBody)
+  , _version (version)
+{
+}
+
+apouche::HttpMessage::~HttpMessage()
+{
+  delete _header;
+  delete _body;
 }
 
 apouche::IHttpHeader *apouche::HttpMessage::getHeaders() {
@@ -19,6 +26,7 @@ const apouche::IHttpHeader *apouche::HttpMessage::getHeaders() const {
 }
 
 void apouche::HttpMessage::setHeaders(IHttpHeader *header) {
+    delete _header;
     _header = header;
 }
 
@@ -31,6 +39,7 @@ const apouche::IHttpBody *apouche::HttpMessage::getBody() const {
 }
 
 void apouche::HttpMessage::setBody(IHttpBody *body) {
+    delete _body;
     _body = body;
 }
 

--- a/HttpMessage/HttpMessage.hh
+++ b/HttpMessage/HttpMessage.hh
@@ -49,7 +49,7 @@ namespace apouche {
         *
         *  Destructor of HttpMessage
         */
-        ~HttpMessage(){};
+        ~HttpMessage();
         /*!
         *  \brief Get the IHttpHeader of your message, you can give you own implementation or use our implementation.
         *
@@ -64,7 +64,7 @@ namespace apouche {
          */
         const IHttpHeader *getHeaders() const override;
         /*!
-        *  \brief Set the IHttpHeader of your request or response
+        *  \brief Delete the old header and set the IHttpHeader of your message
         *
         *  Set the IHttpHeader of your request or response
         *
@@ -86,7 +86,7 @@ namespace apouche {
          */
         const IHttpBody *getBody() const override;
         /*!
-        *  \brief Set the IHttpBody of your request or response
+        *  \brief Delete the old body and set the IHttpBody of your message
         *
         *  Set the IHttpBody of your request or response
         *

--- a/HttpMessage/IHttpMessage.hh
+++ b/HttpMessage/IHttpMessage.hh
@@ -46,7 +46,7 @@ namespace apouche {
          */
         virtual const IHttpHeader *getHeaders() const = 0;
         /*!
-        *  \brief Set the IHttpHeader of your request or response
+        *  \brief Delete the old header and set the IHttpHeader of your message
         *
         *  Set the IHttpHeader of your request or response
         *
@@ -68,7 +68,7 @@ namespace apouche {
          */
         virtual const IHttpBody *getBody() const = 0;
         /*!
-        *  \brief Set the IHttpBody of your request or response
+        *  \brief Delete the old body and set the IHttpBody of your message
         *
         *  Set the IHttpBody of your request or response
         *

--- a/HttpRequest/HttpRequest.cpp
+++ b/HttpRequest/HttpRequest.cpp
@@ -7,7 +7,8 @@
 #include <iostream>
 
 apouche::HttpRequest::~HttpRequest() {
-
+  delete _header;
+  delete _body;
 }
 
 apouche::Method apouche::HttpRequest::getMethod() const {
@@ -59,6 +60,7 @@ const apouche::IHttpHeader *apouche::HttpRequest::getHeaders() const {
 }
 
 void apouche::HttpRequest::setHeaders(IHttpHeader *header) {
+    delete _header;
     _header = header;
 }
 
@@ -71,6 +73,7 @@ const apouche::IHttpBody *apouche::HttpRequest::getBody() const {
 }
 
 void apouche::HttpRequest::setBody(IHttpBody *body) {
+    delete _body;
     _body = body;
 }
 
@@ -82,10 +85,10 @@ void apouche::HttpRequest::setVersion(const std::string &version) {
     _version = version;
 }
 
-apouche::HttpRequest::HttpRequest(const std::string &message, apouche::IHttpBody *body, apouche::IHttpHeader *header) {
-    setHeaders(header);
-    setBody(body);
-
+apouche::HttpRequest::HttpRequest(const std::string &message, apouche::IHttpBody *body, apouche::IHttpHeader *header)
+  : _header (header)
+  , _body (body)
+{
     std::istringstream ss(message);
     std::string token;
 

--- a/HttpRequest/HttpRequest.hh
+++ b/HttpRequest/HttpRequest.hh
@@ -146,7 +146,7 @@ namespace apouche {
          */
         const IHttpHeader *getHeaders() const override;
         /*!
-        *  \brief Set the IHttpHeader of your request
+        *  \brief Delete the old header and set the IHttpHeader of your request
         *
         *  Set the IHttpHeader of your request
         *
@@ -168,7 +168,7 @@ namespace apouche {
          */
         const IHttpBody *getBody() const override;
         /*!
-        *  \brief Set the IHttpBody of your request
+        *  \brief Delete the old body and set the IHttpBody of your request
         *
         *  Set the IHttpBody of your request
         *

--- a/HttpResponse/HttpResponse.cpp
+++ b/HttpResponse/HttpResponse.cpp
@@ -5,7 +5,8 @@
 #include "HttpResponse.hh"
 
 apouche::HttpResponse::~HttpResponse() {
-
+  delete _header;
+  delete _body;
 }
 
 apouche::StatusCode apouche::HttpResponse::getStatus() const {
@@ -29,6 +30,7 @@ const apouche::IHttpHeader *apouche::HttpResponse::getHeaders() const {
 }
 
 void apouche::HttpResponse::setHeaders(IHttpHeader *header) {
+    delete _header;
     _header = header;
 }
 
@@ -41,6 +43,7 @@ const apouche::IHttpBody *apouche::HttpResponse::getBody() const {
 }
 
 void apouche::HttpResponse::setBody(IHttpBody *body) {
+    delete _body;
     _body = body;
 }
 
@@ -53,9 +56,10 @@ void apouche::HttpResponse::setVersion(const std::string &version) {
 }
 
 
-apouche::HttpResponse::HttpResponse(apouche::IHttpHeader *header, apouche::IHttpBody *body, const std::string &version) {
-    setHeaders(header);
-    setBody(body);
+apouche::HttpResponse::HttpResponse(apouche::IHttpHeader *header, apouche::IHttpBody *body, const std::string &version)
+  : _header (header)
+  , _body (body)
+{
 }
 
 const std::string &apouche::HttpResponse::getStatusDescription() const {

--- a/HttpResponse/HttpResponse.hh
+++ b/HttpResponse/HttpResponse.hh
@@ -89,7 +89,7 @@ namespace apouche {
          */
         const IHttpHeader *getHeaders() const override;
         /*!
-        *  \brief Set the IHttpHeader of your response
+        *  \brief Delete the old header and set the IHttpHeader of your response
         *
         *  Set the IHttpHeader of your response
         *
@@ -111,7 +111,7 @@ namespace apouche {
          */
         const IHttpBody *getBody() const override;
         /*!
-        *  \brief Set the IHttpBody of your response
+        *  \brief Delete the old body and set the IHttpBody of your response
         *
         *  Set the IHttpBody of your response
         *


### PR DESCRIPTION
- The destructors of HttpMessage, HttpRequest and HttpResponse now delete the header and body