### PR TITLE
Modification des handlers (cohérence) et Ajout methode IZiaConnection

### DIFF
--- a/EventHandler/EventHandler.hpp
+++ b/EventHandler/EventHandler.hpp
@@ -35,9 +35,9 @@ namespace apouche {
     public:
         EventList<void(IHttpConf *, INetworkStatus *)> _onNetworkIO; // will handle network input/output operations
         EventList<void(IZiaConnection *, IHttpConf *)> _afterConnect;
-        EventList<void(IHttpRequest *, IHttpConf *)> _requestReceived;
-        EventList<void(IHttpRequest *, IHttpConf *)> _beforeParsingRequest;
+        EventList<void(IHttpConf *)> _beforeParsingRequest;
         EventList<void(IHttpRequest *, IHttpConf *)> _afterParsingRequest;
+        EventList<void(IHttpRequest *, IHttpConf *, IZiaConnection *)> _requestReceived;
         EventList<void(IHttpRequest *, IHttpConf *)> _beforeCreateResponse;
         EventList<void(IHttpRequest *, IHttpResponse *, IHttpConf *)> _afterCreateResponse;
         EventList<bool(IHttpResponse *, IHttpConf *)> _beforeSendResponse;

--- a/Network/IZiaConnection.hpp
+++ b/Network/IZiaConnection.hpp
@@ -52,6 +52,12 @@ namespace apouche
          * @return The internal list of requests freshly received
          */
         virtual std::vector<IHttpRequest *> const &getRequests() const = 0;
+
+        /**
+         * @brief Get the next request pending inside the Connection
+         * @return A new HttpRequest
+         */
+        virtual IHttpRequest    *getNextRequest() = 0;
     };
 }
 


### PR DESCRIPTION
- modification des handlers _beforeParsing qui ne prend plus de request en argument (logique elle n'est pas encore parsée)
- déplacement du _requestReceived après le _afterParsingRequest pour la cohérence des appels
- ajout d'un méthode getNextRequest dans IZiaConnection qui va parser la prochaine requête et la renvoyer